### PR TITLE
Backport STDCALL content quote master > nsis2

### DIFF
--- a/SCons/Config/gnu
+++ b/SCons/Config/gnu
@@ -31,7 +31,7 @@ defenv['ALIGN_FLAG'] = '-Wl,--file-alignment,512'
 defenv['CPP_REQUIRES_STDLIB'] = 1
 defenv['SUBSYS_CON'] = '-Wl,--subsystem,console'
 defenv['MSVCRT_FLAG'] = ''
-defenv['STDCALL'] = '__attribute__((__stdcall__))'
+defenv['STDCALL'] = '"__attribute__((__stdcall__))"'
 
 ### defines
 


### PR DESCRIPTION
After the whitespace change in a0a0ba98c69cbb01feae9284f965d343d9613654 in the scons/config/gnu file  the nsis2 branch does not compile anymore as the define is not escaped anymore:
```i686-w64-mingw32-gcc -o build/release/AdvSplash/advsplash.o -c -Os -Wall -fno-strict-aliasing -DNSISCALL=__attribute__((__stdcall__)) -Ibuild/release/api Contrib/AdvSplash/advsplash.c
sh: -c: line 0: syntax error near unexpected token `('```

After patch:
```i686-w64-mingw32-gcc -o build/release/AdvSplash/advsplash.o -c -Os -Wall -fno-strict-aliasing -DNSISCALL="__attribute__((__stdcall__))" -Ibuild/release/api Contrib/AdvSplash/advsplash.c```