### PR TITLE
i686-w64-mingw32 - 32-bit cross compiler support

### DIFF
--- a/SCons/Tools/crossmingw.py
+++ b/SCons/Tools/crossmingw.py
@@ -58,6 +58,7 @@ prefixes = SCons.Util.Split("""
     i486-pc-mingw32-
     i586-pc-mingw32-
     i686-pc-mingw32-
+    i686-w64-mingw32-
 """)
 
 def find(env):


### PR DESCRIPTION
This little change allow 32bit cross-compilation with MinGW-w64.

Example of use that fails without this change:
$ export CC=i686-w64-mingw32-gcc 
$ export CXX=i686-w64-mingw32-g++ 
$ scons UNICODE=yes ZLIB_W32=../zlib PREFIX=install_dir install
