### PR TITLE
Fix for GCC 10 default of -fno-common

### DIFF
--- a/Docs/src/bin/halibut/halibut.h
+++ b/Docs/src/bin/halibut/halibut.h
@@ -269,7 +269,7 @@ void licence(void);
  * version.c
  */
 void initversionstring(void);
-const char *const version;
+extern const char *const version;
 
 /*
  * misc.c


### PR DESCRIPTION
see https://bugzilla.redhat.com/show_bug.cgi?id=1799650