### PR TITLE
Honour SOURCE_DATE_EPOCH for VERSION default

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -96,8 +96,8 @@ default_doctype = 'html'
 if defenv.WhereIs('hhc', os.environ['PATH']):
 	default_doctype = 'chm'
 
-from time import strftime, gmtime
-cvs_version = strftime('%d-%b-%Y.cvs', gmtime())
+import time
+cvs_version = time.strftime('%d-%b-%Y.cvs', time.gmtime(int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))))
 
 opts = Variables()
 


### PR DESCRIPTION
When building `nsis`, if `VERSION` is not specified, it defaults to `cvs_version` which is non-deterministic as it includes the current date.

The patch fixes this by defaulting to `SOURCE_DATE_EPOCH` if possible.