### PR TITLE
Fix typos found by codespell

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = Language files,GenPat,7zip,boost,bzip2,exehead,zlib
+ignore-words-list = atleast,claus,complies,fave,fo,htmp,inbetween,isnt,msdos,nd,nnumber,pard,parms,,pres,ptd,ressize,ro,siz,statics,thats,unknwn,wit

--- a/Docs/src/history.but
+++ b/Docs/src/history.but
@@ -1374,7 +1374,7 @@ Released on December 24th, 2007
 
 \b Fixed build issues on Mac OS (\W{http://sourceforge.net/support/tracker.php?aid=1851365}{bug #1851365})
 
-\b Fixed endianity issues introduced in version 2.32 (\W{http://sourceforge.net/support/tracker.php?aid=1851365}{bug #1851365})
+\b Fixed endianness issues introduced in version 2.32 (\W{http://sourceforge.net/support/tracker.php?aid=1851365}{bug #1851365})
 
 \H{v2.33} 2.33
 
@@ -2156,7 +2156,7 @@ Released on April 7th, 2006
 
 \b The script compiler, makensis, builds and works on big-endian platforms. This change enlarges the portability range of NSIS to theoretically every POSIX platform. Please \W{http://sourceforge.net/tracker/?group_id=22049&atid=373085}{report} any incompatibility with specific platforms or build-tools.
 
-\b The internal changes made to support big-endian platforms also pave the road to x64 installers. There is now a central function which writes data to disk. This function currently only converts the endianity of integers, but it can be changed to selectively write 64-bit integers. Hopefully, there'll soon be a simple method of compiling a script to both x86 and x64 installers.
+\b The internal changes made to support big-endian platforms also pave the road to x64 installers. There is now a central function which writes data to disk. This function currently only converts the endianness of integers, but it can be changed to selectively write 64-bit integers. Hopefully, there'll soon be a simple method of compiling a script to both x86 and x64 installers.
 
 \b Changing Source/exehead/fileform.h to alter the internal structure of installers is no longer enough. The compiler has its own definitions of the structures which must also be changed in Source/fileform.cpp. In the future, fileform.cpp should be automatically generated from fileform.h, but for now, the synchronization must be done manually.
 

--- a/Include/StrFunc.txt
+++ b/Include/StrFunc.txt
@@ -660,7 +660,7 @@ reduced.
 - Renamed header file to "StrFunc.nsh".
 - Added 1 function, StrLoc.
 - Modified StrStrAdv, removed some lines.
-- Fixed StrTok, 2 simple numbers made it loop everytime.
+- Fixed StrTok, 2 simple numbers made it loop every time.
 - Fixed some small issues on the header file.
 
 0.02 - 01/24/2004


### PR DESCRIPTION
Some typos are in user-visible strings and documentation, others are in code comments.

In the long term, I recommend fixing all typos, including those in code comments, because tools like codespell do not make a difference between code comments and documentation and user-visible strings.

I have left out typos in `Contrib`, they should be fixed upstream.