### PR TITLE
Feat/convert-to-console

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# NSIS
+# NSIS (Console)
+
+Modified `makensis` that will build installers as console applications.
 
 [![Build, Test and Publish](https://github.com/kichik/nsis/actions/workflows/build.yml/badge.svg)](https://github.com/kichik/nsis/actions/workflows/build.yml) [![Copy from SourceForge Subversion](https://github.com/kichik/nsis/actions/workflows/copy-svn.yml/badge.svg)](https://github.com/kichik/nsis/actions/workflows/copy-svn.yml)
 
@@ -9,3 +11,4 @@ NSIS (Nullsoft Scriptable Install System) is a professional open source system t
    * [Simple tutorial](https://nsis.sourceforge.io/Simple_tutorials)
    * [NSIS Homepage](https://nsis.sourceforge.io/)
    * [User Manual](https://nsis.sourceforge.io/Docs/)
+   * [Building](https://nsis.sourceforge.io/Docs/AppendixG.html)

--- a/Source/build.cpp
+++ b/Source/build.cpp
@@ -2446,6 +2446,8 @@ int CEXEBuild::UpdatePEHeader()
       *GetCommonMemberFromPEOptHdr(headers->OptionalHeader, MajorSubsystemVersion) = FIX_ENDIAN_INT16(PESubsysVerMaj);
       *GetCommonMemberFromPEOptHdr(headers->OptionalHeader, MinorSubsystemVersion) = FIX_ENDIAN_INT16(PESubsysVerMin);
     }
+    // Run as console application
+    *GetCommonMemberFromPEOptHdr(headers->OptionalHeader, Subsystem) = FIX_ENDIAN_INT16(3);
     // DllCharacteristics
     *GetCommonMemberFromPEOptHdr(headers->OptionalHeader, DllCharacteristics) = FIX_ENDIAN_INT16(PEDllCharacteristics);
   } catch (std::runtime_error& err) {


### PR DESCRIPTION
Modifies `build.cpp` PE header section to set the `Subsystem` type to `IMAGE_SUBSYSTEM_WINDOWS_CUI`.