### PR TITLE
New Windows 10 versions

### DIFF
--- a/Include/WinVer.nsh
+++ b/Include/WinVer.nsh
@@ -679,9 +679,12 @@
   !insertmacro WinVer_WaaS "${id}" 19041 2004 "20H1"        "May 2020 Update" ; 19041.264?
   !insertmacro WinVer_WaaS "${id}" 19042 20H2 "20H2"        "October 2020 Update" ; 19042.572? A.K.A. 2009
   !insertmacro WinVer_WaaS "${id}" 19043 21H1 "21H1"        "May 2021 Update" ; 19043.928
-  !insertmacro WinVer_WaaS "${id}" 19044 21H2 "21H2"        "November 2021 Update"
+  !insertmacro WinVer_WaaS "${id}" 19044 21H2 "21H2"        "November 2021 Update" ; 19044.1288
+  !insertmacro WinVer_WaaS "${id}" 19045 "?"  "22H2"        "October 2022 Update" ; 19045.2130	
+  !insertmacro WinVer_WaaS "${id}" 20348 "?"  "Iron"        "Windows Server 2022" ; 10.0.20348.230
   !insertmacro WinVer_WaaS "${id}" 22000 "?"  "Sun Valley"  "Windows 11" ; 10.0.22000.194 21H2
   !insertmacro WinVer_WaaS "${id}" 22621 22H2 "Sun Valley 2" "2022 Update" ; 10.0.22621.521
+  ;!insertmacro WinVer_WaaS "${id}" 22449 "?" "Sun Valley 3" "2023 Update" ; 10.0.22449
 
   !ifmacrodef WinVerExternal_WaaS_MapToBuild
     !insertmacro WinVerExternal_WaaS_MapToBuild ${op} "${id}" WinVer_WaaS_Build


### PR DESCRIPTION
1. Added full version number for Windows 10 version 21h2 as a comment
2. Added Windows 10 version 22h2. (This shares a feature update value with Windows 11. So, I left it as a "?"; same as Windows 11 RTM)
3. Added Windows Server 2022. Not sure if it goes here; but it has it's own WaaS build number, unlike Windows Server 2016 (1607) and Windows Server 2019 (1809).  3a. The codename "Iron" comes from here (https://en.wikipedia.org/wiki/List_of_Microsoft_codenames#Windows_NT_family), but the feature update is shown as 21H2.
4. Added Windows 11 2023 update. I commented it out since it's still an insider build.

I'm curious how you'd like to handle duplicate feature update and codename values, since it looks like Microsoft will continue to share update names between Windows 10 and Windows 11 (ex. 21H2, 22H2)