### PR TITLE
Fix where redirecting URLs may not include schemes or hosts

### DIFF
--- a/Contrib/NSISdl/httpget.cpp
+++ b/Contrib/NSISdl/httpget.cpp
@@ -393,7 +393,50 @@ run_again:
         char *p=buf+9; while (*p== ' ') p++;
         if (*p)
         {
-          connect(p);
+          char newurl[1024];
+
+          lstrcpyA(newurl, p);
+          if (my_strnicmp(newurl, "http://", 7))
+          {
+            char *q;
+
+            // generate full URL from original
+            lstrcpyA(newurl, m_http_url);
+
+            if (p[0] == '/')
+            {
+              // new location is an absolute path
+              q=&(newurl[7]);
+              while (*q != 0)
+              {
+                if (*q == '/')
+                {
+                  *q=0;
+                  break;
+                }
+                q++;
+              }
+            }
+            else
+            {
+              // new location is an relative path
+              q=&(newurl[lstrlenA(newurl) - 1]);
+              while (q >= newurl)
+              {
+                if (*q == '/')
+                {
+                  *q=0;
+                  break;
+                }
+                q--;
+              }
+
+              lstrcatA(newurl, "/");
+            }
+
+            lstrcatA(newurl, p);
+          }
+          connect(newurl);
           return 0;
         }
       }


### PR DESCRIPTION
Section 7.1.2 in RFC-7231 defines a "Location:" header for specifying the destination URL,
it may not contain schemes or hosts as shown in the example ("Location: /People.html#tim").

https://www.rfc-editor.org/rfc/rfc7231

However in NSISdl current implementation, the Location header's content is passed to the
connect() method as-is, so the first part up to "/" is interpreted as the host name,
so it fails.

This patch makes it possible to regenerate the destination URL from the original one.