### PR TITLE
Fix source comment typos

### DIFF
--- a/Include/StrFunc.nsh
+++ b/Include/StrFunc.nsh
@@ -1300,7 +1300,7 @@ o-----------------------------------------------------------------------------o
           ${EndIf}
         ${EndIf}
 
-        ; After the comparasion, confirm that it is the
+        ; After the comparison, confirm that it is the
         ; value we want.
 
         ${If} $R3 = 1

--- a/Source/exehead/Ui.c
+++ b/Source/exehead/Ui.c
@@ -1005,7 +1005,7 @@ static INT_PTR CALLBACK DirProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM l
     // my_SetWindowText triggers an EN_CHANGE message that
     // triggers a WM_IN_UPDATEMSG message that uses m_curwnd
     // to get the selected directory (GetUIText).
-    // because m_curwnd is still outdated, dir varialble is
+    // because m_curwnd is still outdated, dir variable is
     // filled with an empty string. by default, dir points
     // to $INSTDIR.
     //

--- a/Source/util.cpp
+++ b/Source/util.cpp
@@ -704,7 +704,7 @@ UINT64 get_file_size64(FILE *f)
 UINT64 get_file_size64(FILE *f)
 {
   UINT64 result = invalid_file_size64;
-  // 32bit plaforms require _FILE_OFFSET_BITS = 64 to correctly return the size
+  // 32bit platforms require _FILE_OFFSET_BITS = 64 to correctly return the size
 #if _XOPEN_SOURCE >= 500 || _POSIX_C_SOURCE >= 200112L
   struct stat st;
   if (0 == fstat(fileno(f), &st) && st.st_size <= (sizeof(st.st_size) >= 8 ? (off_t)0x7fffffffffffffffLL : LONG_MAX))


### PR DESCRIPTION
Found via `codespell -q3 -S "./Contrib/Language files" -L isnt,parms,pres,ressize,siz`