### PR TITLE
Korean: add missing MULTIUSER_INSTALLMODEPAGE strings

### DIFF
--- a/Contrib/Language files/Korean.nsh
+++ b/Contrib/Language files/Korean.nsh
@@ -119,3 +119,11 @@
 !ifdef MUI_UNABORTWARNING
   ${LangFileString} MUI_UNTEXT_ABORTWARNING "$(^Name) 제거를 취소하시겠습니까?"
 !endif
+
+!ifdef MULTIUSER_INSTALLMODEPAGE
+  ${LangFileString} MULTIUSER_TEXT_INSTALLMODE_TITLE "설치 모드 선택"
+  ${LangFileString} MULTIUSER_TEXT_INSTALLMODE_SUBTITLE "모든 사용자용 또는 현재 사용자용으로만 설치"
+  ${LangFileString} MULTIUSER_INNERTEXT_INSTALLMODE_TOP "이 애플리케이션을 누구를 위해 설치하시겠습니까?"
+  ${LangFileString} MULTIUSER_INNERTEXT_INSTALLMODE_ALLUSERS "이 컴퓨터를 사용하는 모든 사용자(모든 사용자)"
+  ${LangFileString} MULTIUSER_INNERTEXT_INSTALLMODE_CURRENTUSER "현재 사용자만"
+!endif


### PR DESCRIPTION
## Summary

Adds the five `MULTIUSER_INSTALLMODEPAGE` `LangString` translations that were missing from `Contrib/Language files/Korean.nsh`:

- `MULTIUSER_TEXT_INSTALLMODE_TITLE`
- `MULTIUSER_TEXT_INSTALLMODE_SUBTITLE`
- `MULTIUSER_INNERTEXT_INSTALLMODE_TOP`
- `MULTIUSER_INNERTEXT_INSTALLMODE_ALLUSERS`
- `MULTIUSER_INNERTEXT_INSTALLMODE_CURRENTUSER`

Without these, Korean installers that include `MultiUser.nsh` and use the install-mode page fall back to English on that page only, which looks broken in an otherwise fully-translated installer.

The block follows the same `!ifdef MULTIUSER_INSTALLMODEPAGE` structure already used by `TradChinese.nsh`, `Vietnamese.nsh`, `Ukrainian.nsh`, and others.

## Context

I originally fixed this downstream in Tauri (tauri-apps/tauri#15294, where `tauri-bundler` ships its own copy of the NSIS language files), and a Tauri maintainer rightly suggested upstreaming the fix here so that **every** project using NSIS benefits, not just Tauri apps.

## Thanks

I just want to say a sincere thank you to the NSIS project and everyone who maintains it. NSIS is what makes my Windows apps actually start for users — without it I'd have no good way to ship native installers for the small open-source tools I build. It's been quietly powering Windows software for decades, and projects like mine wouldn't reach Windows users at all without it. Truly grateful. 🙏

## Test plan

- [x] File parses (same `${LangFileString}` form already used in this language file and in other languages' MULTIUSER blocks).
- [x] Strings only emitted when `MULTIUSER_INSTALLMODEPAGE` is defined, matching the convention in other language files.
- [ ] Visual verification on a Korean Windows install with a MultiUser-mode installer (happy to provide screenshots if maintainers want them).